### PR TITLE
fix: readd support to deactivate auto-sync which was broken by #32

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -417,9 +417,9 @@ Description: ID to pass other modules in order to refer to this module as a depe
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_null]] <<provider_null,null>> |>= 3
-|[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
+|[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
+|[[provider_null]] <<provider_null,null>> |>= 3
 |===
 
 = Resources

--- a/main.tf
+++ b/main.tf
@@ -95,10 +95,13 @@ resource "argocd_application" "this" {
     }
 
     sync_policy {
-      automated {
-        prune       = var.app_autosync.prune
-        self_heal   = var.app_autosync.self_heal
-        allow_empty = var.app_autosync.allow_empty
+      dynamic "automated" {
+        for_each = toset(var.app_autosync == { "allow_empty" = tobool(null), "prune" = tobool(null), "self_heal" = tobool(null) } ? [] : [var.app_autosync])
+        content {
+          prune       = automated.value.prune
+          self_heal   = automated.value.self_heal
+          allow_empty = automated.value.allow_empty
+        }
       }
 
       retry {


### PR DESCRIPTION
## Description of the changes

This PR re-adds the support to deactivate the auto-sync, which was broken by the use of dynamic Terraform blocks on the PR #32. This is not a breaking change, because users can still use the old way of passing an empty map to the `app_autosync` variable in order do deactivate the auto-sync.

## Breaking change

- [x] No

## Tests executed on which distribution(s)

- [x] EKS (AWS)
- [x] KinD