### PR TITLE
fix!: remove the ArgoCD namespace variable

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -261,14 +261,6 @@ Type: `string`
 
 The following input variables are optional (have default values):
 
-==== [[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-
-Description: Namespace used by Argo CD where the Application and AppProject resources should be created.
-
-Type: `string`
-
-Default: `"argocd"`
-
 ==== [[input_helm_values]] <<input_helm_values,helm_values>>
 
 Description: Helm values, passed as a list of HCL structures. These values are concatenated with the default ones and then passed to the application's charts.
@@ -459,12 +451,6 @@ Description: ID to pass other modules in order to refer to this module as a depe
 [cols="a,a,a,a,a",options="header,autowidth"]
 |===
 |Name |Description |Type |Default |Required
-|[[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-|Namespace used by Argo CD where the Application and AppProject resources should be created.
-|`string`
-|`"argocd"`
-|no
-
 |[[input_helm_values]] <<input_helm_values,helm_values>>
 |Helm values, passed as a list of HCL structures. These values are concatenated with the default ones and then passed to the application's charts.
 |`any`

--- a/main.tf
+++ b/main.tf
@@ -22,7 +22,7 @@ resource "argocd_repository" "private_ssh_repo" {
 resource "argocd_project" "this" {
   metadata {
     name      = var.name
-    namespace = var.argocd_namespace
+    namespace = "argocd"
   }
 
   spec {
@@ -66,7 +66,7 @@ data "utils_deep_merge_yaml" "values" {
 resource "argocd_application" "this" {
   metadata {
     name      = var.name
-    namespace = var.argocd_namespace
+    namespace = "argocd"
   }
 
   timeouts {

--- a/variables.tf
+++ b/variables.tf
@@ -2,12 +2,6 @@
 ## Standard variables
 #######################
 
-variable "argocd_namespace" {
-  description = "Namespace used by Argo CD where the Application and AppProject resources should be created."
-  type        = string
-  default     = "argocd"
-}
-
 variable "helm_values" {
   description = "Helm values, passed as a list of HCL structures. These values are concatenated with the default ones and then passed to the application's charts."
   type        = any


### PR DESCRIPTION
## Description of the changes

Since we are hardcoding the namespace variable on all modules, the variable to set the ArgoCD namespace will no longer be needed as well.

## Breaking change

- [x] Yes (in the module itself): because we removed the `argocd_namespace` variable

## Tests executed on which distribution(s)

- [x] KinD
- [x] AKS (Azure)
- [x] EKS (AWS)